### PR TITLE
Correct typo in SetupMachine.bat

### DIFF
--- a/SetupMachine.bat
+++ b/SetupMachine.bat
@@ -118,7 +118,7 @@ choco install whois  "%*"
 
 cls
 echo "Installing database tools "
-choco install sql-server-expresss "%*"
+choco install sql-server-express "%*"
 choco install sql-server-management-studio "%*"
 choco install mongodb  "%*"
 choco install robomongo "%*"


### PR DESCRIPTION
Removing extra s at the end of sql-server-express